### PR TITLE
Resolved Infinite Loop with Invalid Projects and Support for Wildcards for Documents

### DIFF
--- a/src/RendleLabs.LegacyWorkspaceLoader/RendleLabs.LegacyWorkspaceLoader.csproj
+++ b/src/RendleLabs.LegacyWorkspaceLoader/RendleLabs.LegacyWorkspaceLoader.csproj
@@ -1,21 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <RootNamespace>RendleLabs.LegacyWorkspaceLoader</RootNamespace>
     </PropertyGroup>
     
     <PropertyGroup>
-        <PackageId>RendleLabs.LegacyWorkspaceLoader</PackageId>
+        <PackageId>scott.munro.LegacyWorkspaceLoader</PackageId>
         <Authors>RendleLabs</Authors>
         <Description>Loads old-style .NET projects in .NET Core.</Description>
         <Copyright>2020 RendleLabs Ltd.</Copyright>
         <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <RepositoryUrl>https://github.com/RendleLabs/LegacyWorkspaceLoader</RepositoryUrl>
+        <RepositoryUrl>https://github.com/samunro/LegacyWorkspaceLoader</RepositoryUrl>
+        <Version>1.1.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/RendleLabs.LegacyWorkspaceLoader/WorkspaceLoader.cs
+++ b/src/RendleLabs.LegacyWorkspaceLoader/WorkspaceLoader.cs
@@ -54,8 +54,6 @@ namespace RendleLabs.LegacyWorkspaceLoader
                 var validProjects = projects
                     .Where(p => p.ProjectReferences.All(_projectInfos.ContainsKey))
                     .ToArray();
-                
-
 
                 if(!validProjects.Any()) break;
                 

--- a/src/RendleLabs.LegacyWorkspaceLoader/WorkspaceLoader.cs
+++ b/src/RendleLabs.LegacyWorkspaceLoader/WorkspaceLoader.cs
@@ -55,6 +55,10 @@ namespace RendleLabs.LegacyWorkspaceLoader
                     .Where(p => p.ProjectReferences.All(_projectInfos.ContainsKey))
                     .ToArray();
                 
+
+
+                if(!validProjects.Any()) break;
+                
                 foreach (var project in validProjects)
                 {
                     var info = CreateProjectInfo(project);

--- a/test/RendleLabs.LegacyWorkspaceLoader.IntegrationTests/RendleLabs.LegacyWorkspaceLoader.IntegrationTests.csproj
+++ b/test/RendleLabs.LegacyWorkspaceLoader.IntegrationTests/RendleLabs.LegacyWorkspaceLoader.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/RendleLabs.LegacyWorkspaceLoader.Tests/RendleLabs.LegacyWorkspaceLoader.Tests.csproj
+++ b/test/RendleLabs.LegacyWorkspaceLoader.Tests/RendleLabs.LegacyWorkspaceLoader.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
As the title suggests. This is really two changes. They are small and I don't have experience with splitting pull requests so I hope that this is OK?

1. Infinite Loop with Invalid Projects
My first attempt at using LegacyWorkspaceLoader almost left me with the assumption that the performance was so bad that I would not be able to use it. It turns out that there was actually a tight, endless loop that was trying unsuccessfully to reduce the number of invalid projects to zero. The solution I was working with does not include all of the projects that are included in project references and they were being classed as invalid. Visual Studio adds an exclamation mark to the reference but does load the referencing project.

The change that I made below on line 60 bails out if the current iteration is not going to reduce the number of invalid projects. An alternative would be to load those projects despite having project references that are not satisfied. That might more closely match the Visual Studio behaviour. I did not test with that though.

2. Support for Wildcards for Documents
Projects in the solution that I tested with included documents with a wildcard expression like this.

`  <ItemGroup>
    <Compile Include="Entities\*.cs" />
  </ItemGroup>
`

The existing code did not handle this and my change ensures that CreateDocumentInfo loads all documents that match the expression. It returns an IEnumerable<DocumentInfo> as there could be multiple matches. Maybe the name of the method should also be changed to reflect this - CreateDocumentInfos?